### PR TITLE
Fix splash screen image loading and timer handling

### DIFF
--- a/Unit1.pas
+++ b/Unit1.pas
@@ -12,7 +12,7 @@ type
     Label1: TLabel;
   private
     { Private declarations }
-    sValriable : String;
+    sVariable : String;
   public
     { Public declarations }
   end;

--- a/Unit2.pas
+++ b/Unit2.pas
@@ -3,8 +3,8 @@ unit Unit2;
 interface
 
 uses
-  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.ExtCtrls, Vcl.Imaging.GIFImg,
+  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, System.IOUtils,
+  Vcl.Graphics, Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.ExtCtrls, Vcl.Imaging.GIFImg,
   Vcl.MPlayer;
 
 type
@@ -29,17 +29,24 @@ implementation
 {$R *.dfm}
 
 procedure TForm2.FormShow(Sender: TObject);
+var
+  gifPath: string;
 begin
   vCompletado := False;
 
-  Image1.picture.loadfromfile('C:\PMS-I DELPHI11 Produccion\Bmp_Usados\PMS - Logo circulos.gif');
-  (Image1.Picture.Graphic as TgifImage).Animate:=true;
-
+  gifPath := TPath.Combine(ExtractFilePath(ParamStr(0)),
+    TPath.Combine('Bmp_Usados', 'PMS - Logo circulos.gif'));
+  if FileExists(gifPath) then
+  begin
+    Image1.Picture.LoadFromFile(gifPath);
+    (Image1.Picture.Graphic as TGIFImage).Animate := True;
+  end;
 end;
 
 procedure TForm2.TmrSplashTimer(Sender: TObject);
 begin
-   vCompletado := True;
+  vCompletado := True;
+  TmrSplash.Enabled := False;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Load splash screen GIF from application directory and skip animation when missing
- Disable splash timer after completion to prevent repeated triggers
- Correct typo in variable name

## Testing
- `fpc Project1.dpr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8465b95c832a918bb6de5c93fa59